### PR TITLE
Remove unused import

### DIFF
--- a/fastpt/matter_power_spt.py
+++ b/fastpt/matter_power_spt.py
@@ -12,7 +12,6 @@ email : jmcewen314@gmail.com
 
 import numpy as np
 from numpy import log, sqrt, exp, pi
-from scipy.integrate import trapz
 from scipy.signal import fftconvolve
 from .J_k import J_k
 import sys


### PR DESCRIPTION
This line is not used, but it causes `ImportError`.